### PR TITLE
CPLP-679: more efficient linq limits the amount of data to what is actually needed

### DIFF
--- a/src/marketplace/CatenaX.NetworkServices.App.Service/BusinessLogic/AppsBusinessLogic.cs
+++ b/src/marketplace/CatenaX.NetworkServices.App.Service/BusinessLogic/AppsBusinessLogic.cs
@@ -13,29 +13,37 @@ namespace CatenaX.NetworkServices.App.Service.BusinessLogic
             this.context = context;
         }
 
-        public async Task<IEnumerable<AppViewModel>> GetAllActiveAppsAsync(string? languageShortName = null)
+        public async IAsyncEnumerable<AppViewModel> GetAllActiveAppsAsync(string? languageShortName = null)
         {
-            var activeApps = await this.context.Apps.AsNoTracking()
-                .Include(a => a.AppDescriptions)
-                .Include(a => a.VendorCompany)
-                .Include(a => a.UseCases)
-                .Include(a => a.AppLicenses)
-                .Where(a => a.DateReleased.HasValue && a.DateReleased <= DateTime.UtcNow)
-                .ToListAsync();
-
-            var mappedApps = activeApps.Select(a => new AppViewModel
-            {
-                Id = a.Id,
-                Title = a.Name ?? "",
-                Provider = a.VendorCompany?.Name ?? "",
-                UseCases = a.UseCases.Select(uc => uc.Name ?? "").ToList(),
-                LeadPictureUri = a.ThumbnailUrl ?? "",
-                ShortDescription = languageShortName is null ? 
-                    "" : 
-                    a.AppDescriptions.FirstOrDefault(ad => ad.AppId == a.Id && ad.LanguageShortName == languageShortName)?.DescriptionShort ?? "",
-                Price = a.AppLicenses.FirstOrDefault()?.Licensetext ?? ""
-            });
-            return mappedApps;
+            await foreach(var app in context.Apps.AsQueryable()
+                .Where(app => app.DateReleased.HasValue && app.DateReleased <= DateTime.UtcNow)
+                .Select(a => new {
+                    Id = a.Id,
+                    Name = a.Name,
+                    VendorCompanyName = a.VendorCompany!.Name, // This translates into a 'left join' which does return null for all columns if the foreingn key is null. The '!' just makes the compiler happy
+                    UseCaseNames = a.UseCases.Select(uc => uc.Name),
+                    ThumbnailUrl = a.ThumbnailUrl,
+                    ShortDescription = languageShortName == null
+                        ? null
+                        : a.AppDescriptions
+                            .Where(description => description.LanguageShortName == languageShortName)
+                            .Select(description => description.DescriptionShort)
+                            .SingleOrDefault(),
+                    LicenseText = a.AppLicenses
+                        .Select(license => license.Licensetext)
+                        .FirstOrDefault()
+                }).AsAsyncEnumerable())
+                {
+                    yield return new AppViewModel {
+                        Id = app.Id,
+                        Title = app.Name ?? "",
+                        Provider = app.VendorCompanyName ?? "",
+                        UseCases = app.UseCaseNames.Select(name => name ?? "").ToList(),
+                        LeadPictureUri = app.ThumbnailUrl ?? "",
+                        ShortDescription = app.ShortDescription ?? "",
+                        Price = app.LicenseText ?? ""
+                    };
+                }
         }
 
         public async Task<IEnumerable<Guid>> GetAllFavouriteAppsForUser(Guid userId)

--- a/src/marketplace/CatenaX.NetworkServices.App.Service/BusinessLogic/AppsBusinessLogic.cs
+++ b/src/marketplace/CatenaX.NetworkServices.App.Service/BusinessLogic/AppsBusinessLogic.cs
@@ -16,6 +16,7 @@ namespace CatenaX.NetworkServices.App.Service.BusinessLogic
         public async IAsyncEnumerable<AppViewModel> GetAllActiveAppsAsync(string? languageShortName = null)
         {
             await foreach(var app in context.Apps.AsQueryable()
+                .AsNoTracking()
                 .Where(app => app.DateReleased.HasValue && app.DateReleased <= DateTime.UtcNow)
                 .Select(a => new {
                     Id = a.Id,

--- a/src/marketplace/CatenaX.NetworkServices.App.Service/BusinessLogic/IAppsBusinessLogic.cs
+++ b/src/marketplace/CatenaX.NetworkServices.App.Service/BusinessLogic/IAppsBusinessLogic.cs
@@ -4,7 +4,7 @@ namespace CatenaX.NetworkServices.App.Service.BusinessLogic
 {
     public interface IAppsBusinessLogic
     {
-        public Task<IEnumerable<AppViewModel>> GetAllActiveAppsAsync(string? languageShortName = null);
+        public IAsyncEnumerable<AppViewModel> GetAllActiveAppsAsync(string? languageShortName = null);
 
         public Task<IEnumerable<Guid>> GetAllFavouriteAppsForUser(Guid userId);
     }

--- a/src/marketplace/CatenaX.NetworkServices.App.Service/CatenaX.NetworkServices.App.Service.csproj
+++ b/src/marketplace/CatenaX.NetworkServices.App.Service/CatenaX.NetworkServices.App.Service.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.14.0" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="5.0.10" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.3.0" />
+    <PackageReference Include="System.Linq.Async" Version="6.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/marketplace/CatenaX.NetworkServices.App.Service/Controllers/AppsController.cs
+++ b/src/marketplace/CatenaX.NetworkServices.App.Service/Controllers/AppsController.cs
@@ -1,6 +1,6 @@
 ﻿using CatenaX.NetworkServices.App.Service.BusinessLogic;
 using Microsoft.AspNetCore.Mvc;
-
+using System.Linq;
 namespace CatenaX.NetworkServices.App.Service.Controllers
 {
     [Route("api/[controller]")]
@@ -20,7 +20,7 @@ namespace CatenaX.NetworkServices.App.Service.Controllers
         [Route("active")]
         public async Task<IActionResult> GetAllActiveApps([FromQuery] string? lang = null)
         {
-            return Ok(await this.appsBusinessLogic.GetAllActiveAppsAsync(lang));
+            return Ok(await this.appsBusinessLogic.GetAllActiveAppsAsync(lang).ToListAsync().ConfigureAwait(false));
         }
     }
 }


### PR DESCRIPTION
the query results generation of in the following sql:

      SELECT a2.id, a2.name, c.name, a2.thumbnail_url, (
          SELECT a.description_short
          FROM portal.app_descriptions AS a
          WHERE (a2.id = a.app_id) AND (a.language_short_name = @__languageShortName_0)
          LIMIT 1), (
          SELECT a1.licensetext
          FROM portal.app_assigned_licenses AS a0
          INNER JOIN portal.app_licenses AS a1 ON a0.app_license_id = a1.id
          WHERE a2.id = a0.app_id
          LIMIT 1), c.id, t.name, t.app_id, t.use_case_id, t.id
      FROM portal.apps AS a2
      LEFT JOIN portal.companies AS c ON a2.vendor_company_id = c.id
      LEFT JOIN (
          SELECT u.name, a3.app_id, a3.use_case_id, u.id
          FROM portal.app_assigned_use_cases AS a3
          INNER JOIN portal.use_cases AS u ON a3.use_case_id = u.id
      ) AS t ON a2.id = t.app_id
      WHERE (a2.date_released IS NOT NULL) AND (a2.date_released <= now() AT TIME ZONE 'UTC')
      ORDER BY a2.id, c.id, t.app_id, t.use_case_id, t.id

setting 'languageShortName' to null dynamically eliminates the part that selects description_short and the generated sql is a bit simpler:

      SELECT a1.id, a1.name, c.name, a1.thumbnail_url, (
          SELECT a0.licensetext
          FROM portal.app_assigned_licenses AS a
          INNER JOIN portal.app_licenses AS a0 ON a.app_license_id = a0.id
          WHERE a1.id = a.app_id
          LIMIT 1), c.id, t.name, t.app_id, t.use_case_id, t.id
      FROM portal.apps AS a1
      LEFT JOIN portal.companies AS c ON a1.vendor_company_id = c.id
      LEFT JOIN (
          SELECT u.name, a2.app_id, a2.use_case_id, u.id
          FROM portal.app_assigned_use_cases AS a2
          INNER JOIN portal.use_cases AS u ON a2.use_case_id = u.id
      ) AS t ON a1.id = t.app_id
      WHERE (a1.date_released IS NOT NULL) AND (a1.date_released <= now() AT TIME ZONE 'UTC')
      ORDER BY a1.id, c.id, t.app_id, t.use_case_id, t.id

besides a few primary-keys (c.id, t.app_id, t.use_case_id, t.id which are not referenced in the query but added to the select by ef-core (for reasons that I do not yet fully understand) this sql does not return any redundant data