### PR TITLE
CPLP-613 simplify dbaccess and businesslogic

### DIFF
--- a/src/provisioning/CatenaX.NetworkServices.Provisioning.DBAccess/IProvisioningDBAccess.cs
+++ b/src/provisioning/CatenaX.NetworkServices.Provisioning.DBAccess/IProvisioningDBAccess.cs
@@ -9,9 +9,8 @@ namespace CatenaX.NetworkServices.Provisioning.DBAccess
     {
         Task<int> GetNextClientSequenceAsync();
         Task<int> GetNextIdentityProviderSequenceAsync();
-        Task SaveUserPasswordResetInfo(string userEntityId, DateTimeOffset passwordModifiedAt, int resetCount);
-        Task<UserPasswordReset> GetUserPasswordResetInfoNoTracking(string userEntityId);
-        Task SetUserPassword(string userEntityId, int count);
-        Task SetUserPassword(string userEntityId, DateTimeOffset dateReset, int count);
+        UserPasswordReset CreateUserPasswordResetInfo(string userEntityId, DateTimeOffset passwordModifiedAt, int resetCount);
+        Task<UserPasswordReset> GetUserPasswordResetInfo(string userEntityId);
+        Task<int> SaveAsync();
     }
 }

--- a/src/provisioning/CatenaX.NetworkServices.Provisioning.DBAccess/ProvisioningDBAccess.cs
+++ b/src/provisioning/CatenaX.NetworkServices.Provisioning.DBAccess/ProvisioningDBAccess.cs
@@ -30,45 +30,23 @@ namespace CatenaX.NetworkServices.Provisioning.DBAccess
             return nextSequence.SequenceId;
         }
 
-        public async Task SaveUserPasswordResetInfo(string userEntityId, DateTimeOffset passwordModifiedAt, int resetCount)
-        {
+        public UserPasswordReset CreateUserPasswordResetInfo(string userEntityId, DateTimeOffset passwordModifiedAt, int resetCount) =>
             _dbContext.UserPasswordResets.Add(
                 new UserPasswordReset(
                     userEntityId,
+                    passwordModifiedAt,
                     resetCount
                 )
-                {
-                    PasswordModifiedAt = passwordModifiedAt,
-                }
-            );
-            await _dbContext.SaveChangesAsync().ConfigureAwait(false);
-        }
+            ).Entity;
 
-        public Task<UserPasswordReset> GetUserPasswordResetInfoNoTracking(string userEntityId)
+        public Task<UserPasswordReset> GetUserPasswordResetInfo(string userEntityId)
         {
             return _dbContext.UserPasswordResets
                 .Where(x => x.UserEntityId == userEntityId)
-                .AsNoTracking()
                 .FirstOrDefaultAsync();
         }
 
-        public async Task SetUserPassword(string userEntityId, int count)
-        {
-            var passwordReset = await _dbContext.UserPasswordResets
-                .Where(x => x.UserEntityId == userEntityId)
-                .SingleAsync();
-            passwordReset.ResetCount = count;
-            await _dbContext.SaveChangesAsync().ConfigureAwait(false);
-        }
-
-        public async Task SetUserPassword(string userEntityId, DateTimeOffset dateReset, int count)
-        {
-            var passwordReset = await _dbContext.UserPasswordResets
-                .Where(x => x.UserEntityId == userEntityId)
-                .SingleAsync();
-            passwordReset.PasswordModifiedAt = dateReset;
-            passwordReset.ResetCount = count;
-            await _dbContext.SaveChangesAsync().ConfigureAwait(false);
-        }
+        public Task<int> SaveAsync() =>
+            _dbContext.SaveChangesAsync();
     }
 }

--- a/src/provisioning/CatenaX.NetworkServices.Provisioning.ProvisioningEntities/Entities/UserPasswordReset.cs
+++ b/src/provisioning/CatenaX.NetworkServices.Provisioning.ProvisioningEntities/Entities/UserPasswordReset.cs
@@ -8,19 +8,21 @@ namespace CatenaX.NetworkServices.Provisioning.ProvisioningEntities
         private UserPasswordReset()
         {
             UserEntityId = default!;
+            PasswordModifiedAt = default!;
             ResetCount = default!;
         }
 
-        public UserPasswordReset(string UserEntityId, int ResetCount)
+        public UserPasswordReset(string UserEntityId, DateTimeOffset PasswordModifiedAt, int ResetCount)
         {
             this.UserEntityId = UserEntityId;
+            this.PasswordModifiedAt = PasswordModifiedAt;
             this.ResetCount = ResetCount;
         }
 
         [Key]
         [StringLength(36)]
         public string UserEntityId { get; private set; }
-        public DateTimeOffset? PasswordModifiedAt { get; set; }
+        public DateTimeOffset PasswordModifiedAt { get; set; }
         public int ResetCount { get; set; }
     }
 }

--- a/src/useradministration/CatenaX.NetworkServices.UserAdministration.Service/BusinessLogic/UserAdministrationBusinessLogic.cs
+++ b/src/useradministration/CatenaX.NetworkServices.UserAdministration.Service/BusinessLogic/UserAdministrationBusinessLogic.cs
@@ -320,35 +320,25 @@ namespace CatenaX.NetworkServices.UserAdministration.Service.BusinessLogic
 
         public async Task<bool> CanResetPassword(string userId)
         {
-            var userInfo = await _provisioningDBAccess.GetUserPasswordResetInfoNoTracking(userId).ConfigureAwait(false);
-            int resetCount = 0;
-            int val = 0;
-            if (userInfo != null)
+            DateTimeOffset now = DateTimeOffset.UtcNow;
+
+            var userInfo = await _provisioningDBAccess.GetUserPasswordResetInfo(userId).ConfigureAwait(false)
+                ?? _provisioningDBAccess.CreateUserPasswordResetInfo(userId, now, 0);
+            
+            if (now < userInfo.PasswordModifiedAt.AddHours(24))
             {
-                if (userInfo.ResetCount > 0 && userInfo.ResetCount < 10)
+                if (userInfo.ResetCount < 10)
                 {
-                    resetCount = (userInfo.ResetCount != null) ? userInfo.ResetCount : 0;
-                    DateTimeOffset dt = userInfo.PasswordModifiedAt ?? DateTimeOffset.UtcNow;
-                    DateTimeOffset now = DateTimeOffset.UtcNow;
-                    if (now < dt.AddHours(24))
-                    {
-                        val = resetCount + 1;
-                        await _provisioningDBAccess.SetUserPassword(userId, val).ConfigureAwait(false);
-                        return true;
-                    }
-                    else if (now > dt.AddHours(24))
-                    {
-                        await _provisioningDBAccess.SetUserPassword(userId, DateTimeOffset.UtcNow, 1).ConfigureAwait(false);
-                        return true;
-                    }
-
+                    userInfo.ResetCount++;
+                    await _provisioningDBAccess.SaveAsync().ConfigureAwait(false);
+                    return true;
                 }
-
             }
             else
             {
-                val = resetCount + 1;
-                await _provisioningDBAccess.SaveUserPasswordResetInfo(userId, DateTimeOffset.UtcNow, val).ConfigureAwait(false);
+                userInfo.ResetCount = 1;
+                userInfo.PasswordModifiedAt = now;
+                await _provisioningDBAccess.SaveAsync().ConfigureAwait(false);
                 return true;
             }
             return false;


### PR DESCRIPTION
@qxz2mqe 
Instead of explaining what I mean when I wrote 'unnecessary complex' I decided to send you a simplified version as PR.
The main difference is: the dbaccess-class does contain simple methods now. Create new entity and retrieve a tracked entity (plus a general purpose 'save' method which will save all changes to the current DBContext)
Now as the businesscode does gets access the tracked object it can just apply the changes to this object and finally save the tracked changes with the DBContext.