### PR TITLE
CPLP-362 add validation of mandatory parameters not being all whitespace

### DIFF
--- a/src/administration/CatenaX.NetworkServices.Administration.Service/BusinessLogic/InvitationBusinessLogic.cs
+++ b/src/administration/CatenaX.NetworkServices.Administration.Service/BusinessLogic/InvitationBusinessLogic.cs
@@ -37,13 +37,21 @@ namespace CatenaX.NetworkServices.Administration.Service.BusinessLogic
 
         public async Task ExecuteInvitation(CompanyInvitationData invitationData)
         {
+            if (String.IsNullOrWhiteSpace(invitationData.email))
+            {
+                throw new ArgumentException("email must not be empty", "email");
+            }
+            if (String.IsNullOrWhiteSpace(invitationData.organisationName))
+            {
+                throw new ArgumentException("organisationName must not be empty", "organisationName");
+            }
             var idpName = await _provisioningManager.GetNextCentralIdentityProviderNameAsync().ConfigureAwait(false);
 
             await _provisioningManager.SetupSharedIdpAsync(idpName, invitationData.organisationName).ConfigureAwait(false);
 
             var password = new Password().Next();
             var centralUserId = await _provisioningManager.CreateSharedUserLinkedToCentralAsync(idpName, new UserProfile(
-                    invitationData.userName,
+                    String.IsNullOrWhiteSpace(invitationData.userName) ? invitationData.email : invitationData.userName,
                     invitationData.email,
                     invitationData.organisationName
             ) {

--- a/src/administration/CatenaX.NetworkServices.Administration.Service/Models/CompanyInvitationData.cs
+++ b/src/administration/CatenaX.NetworkServices.Administration.Service/Models/CompanyInvitationData.cs
@@ -4,7 +4,7 @@ namespace CatenaX.NetworkServices.Administration.Service.Models
 {
     public class CompanyInvitationData
     {
-        public CompanyInvitationData(string userName, string firstName, string lastName, string email, string organisationName)
+        public CompanyInvitationData(string? userName, string firstName, string lastName, string email, string organisationName)
         {
             this.userName = userName;
             this.firstName = firstName;
@@ -14,7 +14,7 @@ namespace CatenaX.NetworkServices.Administration.Service.Models
         }
 
         [JsonPropertyName("userName")]
-        public string userName { get; set; }
+        public string? userName { get; set; }
         [JsonPropertyName("firstName")]
         public string firstName { get; set; }
         [JsonPropertyName("lastName")]


### PR DESCRIPTION
fixing what we just have seen in the demo. Invitation-service should not accept empty or all whitespace email-address and/or organisationName. (Prior only the existence (not nullable) of those parameteres was checked).