### PR TITLE
CPLP-773 add missing AgreementCategories to basedata

### DIFF
--- a/src/portalbackend/CatenaX.NetworkServices.PortalBackend.Migrations/Migrations/20220517170706_InitialCreate.Designer.cs
+++ b/src/portalbackend/CatenaX.NetworkServices.PortalBackend.Migrations/Migrations/20220517170706_InitialCreate.Designer.cs
@@ -12,8 +12,8 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace CatenaX.NetworkServices.PortalBackend.Migrations.Migrations
 {
     [DbContext(typeof(PortalDbContext))]
-    [Migration("20220517121718_Initial")]
-    partial class Initial
+    [Migration("20220517170706_InitialCreate")]
+    partial class InitialCreate
     {
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
@@ -203,6 +203,23 @@ namespace CatenaX.NetworkServices.PortalBackend.Migrations.Migrations
                         .HasName("pk_agreement_categories");
 
                     b.ToTable("agreement_categories", "portal");
+
+                    b.HasData(
+                        new
+                        {
+                            AgreementCategoryId = 1,
+                            Label = "CX_FRAME_CONTRACT"
+                        },
+                        new
+                        {
+                            AgreementCategoryId = 2,
+                            Label = "APP_CONTRACT"
+                        },
+                        new
+                        {
+                            AgreementCategoryId = 3,
+                            Label = "DATA_CONTRACT"
+                        });
                 });
 
             modelBuilder.Entity("CatenaX.NetworkServices.PortalBackend.PortalEntities.Entities.App", b =>

--- a/src/portalbackend/CatenaX.NetworkServices.PortalBackend.Migrations/Migrations/20220517170706_InitialCreate.cs
+++ b/src/portalbackend/CatenaX.NetworkServices.PortalBackend.Migrations/Migrations/20220517170706_InitialCreate.cs
@@ -5,7 +5,7 @@ using Microsoft.EntityFrameworkCore.Migrations;
 
 namespace CatenaX.NetworkServices.PortalBackend.Migrations.Migrations
 {
-    public partial class Initial : Migration
+    public partial class InitialCreate : Migration
     {
         protected override void Up(MigrationBuilder migrationBuilder)
         {
@@ -1045,6 +1045,17 @@ namespace CatenaX.NetworkServices.PortalBackend.Migrations.Migrations
                         principalSchema: "portal",
                         principalTable: "company_users",
                         principalColumn: "id");
+                });
+
+            migrationBuilder.InsertData(
+                schema: "portal",
+                table: "agreement_categories",
+                columns: new[] { "agreement_category_id", "label" },
+                values: new object[,]
+                {
+                    { 1, "CX_FRAME_CONTRACT" },
+                    { 2, "APP_CONTRACT" },
+                    { 3, "DATA_CONTRACT" }
                 });
 
             migrationBuilder.InsertData(

--- a/src/portalbackend/CatenaX.NetworkServices.PortalBackend.Migrations/Migrations/PortalDbContextModelSnapshot.cs
+++ b/src/portalbackend/CatenaX.NetworkServices.PortalBackend.Migrations/Migrations/PortalDbContextModelSnapshot.cs
@@ -201,6 +201,23 @@ namespace CatenaX.NetworkServices.PortalBackend.Migrations.Migrations
                         .HasName("pk_agreement_categories");
 
                     b.ToTable("agreement_categories", "portal");
+
+                    b.HasData(
+                        new
+                        {
+                            AgreementCategoryId = 1,
+                            Label = "CX_FRAME_CONTRACT"
+                        },
+                        new
+                        {
+                            AgreementCategoryId = 2,
+                            Label = "APP_CONTRACT"
+                        },
+                        new
+                        {
+                            AgreementCategoryId = 3,
+                            Label = "DATA_CONTRACT"
+                        });
                 });
 
             modelBuilder.Entity("CatenaX.NetworkServices.PortalBackend.PortalEntities.Entities.App", b =>

--- a/src/portalbackend/CatenaX.NetworkServices.PortalBackend.Migrations/PortalDbContextFactory.cs
+++ b/src/portalbackend/CatenaX.NetworkServices.PortalBackend.Migrations/PortalDbContextFactory.cs
@@ -17,7 +17,7 @@ internal class PortalDbContextFactory : IDesignTimeDbContextFactory<PortalDbCont
         optionsBuilder.UseNpgsql(
             config.GetConnectionString("PortalDb"),
             x => x.MigrationsAssembly(typeof(PortalDbContextFactory).Assembly.GetName().Name)
-                  .MigrationsHistoryTable("__EFMigrationsHistory_portal")
+                  .MigrationsHistoryTable("__efmigrations_history_portal")
         );
 
         return new PortalDbContext(optionsBuilder.Options);

--- a/src/portalbackend/CatenaX.NetworkServices.PortalBackend.PortalEntities/Entities/AgreementCategory.cs
+++ b/src/portalbackend/CatenaX.NetworkServices.PortalBackend.PortalEntities/Entities/AgreementCategory.cs
@@ -11,6 +11,12 @@ public class AgreementCategory
         Agreements = new HashSet<Agreement>();
     }
 
+    public AgreementCategory(AgreementCategoryId agreementCategoryId) : this()
+    {
+        AgreementCategoryId = agreementCategoryId;
+        Label = agreementCategoryId.ToString();
+    }
+
     [Key]
     public AgreementCategoryId AgreementCategoryId { get; private set; }
 

--- a/src/portalbackend/CatenaX.NetworkServices.PortalBackend.PortalEntities/PortalDbContext.cs
+++ b/src/portalbackend/CatenaX.NetworkServices.PortalBackend.PortalEntities/PortalDbContext.cs
@@ -159,6 +159,11 @@ public class PortalDbContext : DbContext
 
             entity.Property(e => e.AgreementCategoryId)
                 .ValueGeneratedNever();
+
+            entity.HasData(
+                Enum.GetValues(typeof(AgreementCategoryId))
+                    .Cast<AgreementCategoryId>()
+                    .Select(e => new AgreementCategory(e)));
         });
 
         modelBuilder.Entity<App>(entity =>


### PR DESCRIPTION
when trying to create devenv-database with the initial migration from scratch the import of testdata failed due to AgreementCategory-data missing in the static base-data.
A did add the missing '.HasData' to the DbContext, then recreated the initial migration. The result did allow to create devenv db from scratch and import testdata afterwards with no errors.
I also change the history table name to all lowercase as pg_dump does not match uppercase characters in table name patterns