### PR TITLE
CPLP-466 fix usage of repository vs. portalDBAccess

### DIFF
--- a/src/portalbackend/CatenaX.NetworkServices.PortalBackend.DBAccess/IPortalBackendDBAccess.cs
+++ b/src/portalbackend/CatenaX.NetworkServices.PortalBackend.DBAccess/IPortalBackendDBAccess.cs
@@ -6,14 +6,13 @@ namespace CatenaX.NetworkServices.PortalBackend.DBAccess
 {
     public interface IPortalBackendDBAccess
     {
-        Company CreateCompany(string companyName);
-        CompanyApplication CreateCompanyApplication(Company company, CompanyApplicationStatusId companyApplicationStatusId);
+        [Obsolete("use IUserRepository instead")]
         CompanyUser CreateCompanyUser(string? firstName, string? lastName, string email, Guid companyId, CompanyUserStatusId companyUserStatusId);
+        [Obsolete("use IApplicationRepository instead")]
         Invitation CreateInvitation(Guid applicationId, CompanyUser user);
         [Obsolete("use IUserRolesRepository instead")]
         CompanyUserAssignedRole CreateCompanyUserAssignedRole(Guid companyUserId, Guid companyUserRoleId);
-        IdentityProvider CreateSharedIdentityProvider(Company company);
-        IamIdentityProvider CreateIamIdentityProvider(IdentityProvider identityProvider, string idpAlias);
+        [Obsolete("use IUserRepository instead")]
         IamUser CreateIamUser(CompanyUser companyUser, string iamUserId);
         Address CreateAddress(string city, string streetname, string countryAlpha2Code);
         Consent CreateConsent(Guid agreementId, Guid companyId, Guid companyUserId, ConsentStatusId consentStatusId, string? Comment = null, string? Target = null, Guid? DocumentId = null);
@@ -39,8 +38,6 @@ namespace CatenaX.NetworkServices.PortalBackend.DBAccess
         IamUser RemoveIamUser(IamUser iamUser);
         IAsyncEnumerable<CompanyRoleData> GetCompanyRoleAgreementsUntrackedAsync();
         IAsyncEnumerable<AgreementData> GetAgreementsUntrackedAsync();
-        [Obsolete("use IUserRolesRepository instead")]
-        IAsyncEnumerable<Guid> GetUserRoleIdsUntrackedAsync(IDictionary<string, IEnumerable<string>> clientRoles);
         IAsyncEnumerable<UserRoleWithId> GetUserRoleWithIdsUntrackedAsync(string clientClientId, IEnumerable<string> companyUserRoles);
         IAsyncEnumerable<InvitedUserDetail> GetInvitedUserDetailsUntrackedAsync(Guid applicationId);
         Task<IdpUser?> GetIdpCategoryIdByUserIdAsync(Guid companyUserId, string adminUserId);

--- a/src/portalbackend/CatenaX.NetworkServices.PortalBackend.DBAccess/PortalBackendDBAccess.cs
+++ b/src/portalbackend/CatenaX.NetworkServices.PortalBackend.DBAccess/PortalBackendDBAccess.cs
@@ -17,22 +17,7 @@ namespace CatenaX.NetworkServices.PortalBackend.DBAccess
             _dbContext = dbContext;
         }
 
-        public Company CreateCompany(string companyName) =>
-            _dbContext.Companies.Add(
-                new Company(
-                    Guid.NewGuid(),
-                    companyName,
-                    CompanyStatusId.PENDING,
-                    DateTimeOffset.UtcNow)).Entity;
-
-        public CompanyApplication CreateCompanyApplication(Company company, CompanyApplicationStatusId companyApplicationStatusId) =>
-            _dbContext.CompanyApplications.Add(
-                new CompanyApplication(
-                    Guid.NewGuid(),
-                    company.Id,
-                    companyApplicationStatusId,
-                    DateTimeOffset.UtcNow)).Entity;
-
+        [Obsolete("user IUserRepository instead")]
         public CompanyUser CreateCompanyUser(string? firstName, string? lastName, string email, Guid companyId, CompanyUserStatusId companyUserStatusId) =>
             _dbContext.CompanyUsers.Add(
                 new CompanyUser(
@@ -46,6 +31,7 @@ namespace CatenaX.NetworkServices.PortalBackend.DBAccess
                     Email = email,
                 }).Entity;
 
+        [Obsolete("user IApplicationRepository instead")]
         public Invitation CreateInvitation(Guid applicationId, CompanyUser user) =>
             _dbContext.Invitations.Add(
                 new Invitation(
@@ -63,22 +49,7 @@ namespace CatenaX.NetworkServices.PortalBackend.DBAccess
                     userRoleId
                 )).Entity;
 
-        public IdentityProvider CreateSharedIdentityProvider(Company company)
-        {
-            var idp = new IdentityProvider(
-                Guid.NewGuid(),
-                IdentityProviderCategoryId.KEYCLOAK_SHARED,
-                DateTimeOffset.UtcNow);
-            idp.Companies.Add(company);
-            return _dbContext.IdentityProviders.Add(idp).Entity;
-        }
-
-        public IamIdentityProvider CreateIamIdentityProvider(IdentityProvider identityProvider, string idpAlias) =>
-            _dbContext.IamIdentityProviders.Add(
-                new IamIdentityProvider(
-                    idpAlias,
-                    identityProvider.Id)).Entity;
-
+        [Obsolete("user IUserRepository instead")]
         public IamUser CreateIamUser(CompanyUser user, string iamUserEntityId) =>
             _dbContext.IamUsers.Add(
                 new IamUser(
@@ -348,23 +319,6 @@ namespace CatenaX.NetworkServices.PortalBackend.DBAccess
 
         public IamUser RemoveIamUser(IamUser iamUser) =>
             _dbContext.Remove(iamUser).Entity;
-
-        [Obsolete("use IUserRolesRepository instead")]
-        public async IAsyncEnumerable<Guid> GetUserRoleIdsUntrackedAsync(IDictionary<string, IEnumerable<string>> clientRoles)
-        {
-            foreach (var clientRole in clientRoles)
-            {
-                await foreach (var userRoleId in _dbContext.UserRoles
-                    .AsNoTracking()
-                    .Where(userRole => userRole.IamClient!.ClientClientId == clientRole.Key && clientRole.Value.Contains(userRole.UserRoleText))
-                    .AsQueryable()
-                    .Select(userRole => userRole.Id)
-                    .AsAsyncEnumerable().ConfigureAwait(false))
-                {
-                    yield return userRoleId;
-                }
-            }
-        }
 
         public IAsyncEnumerable<UserRoleWithId> GetUserRoleWithIdsUntrackedAsync(string clientClientId, IEnumerable<string> userRoles) =>
             _dbContext.UserRoles

--- a/src/portalbackend/CatenaX.NetworkServices.PortalBackend.DBAccess/PortalRepositories.cs
+++ b/src/portalbackend/CatenaX.NetworkServices.PortalBackend.DBAccess/PortalRepositories.cs
@@ -16,13 +16,29 @@ public class PortalRepositories : IPortalRepositories
     {
         var repositoryType = typeof(RepositoryType);
 
-        if (repositoryType == typeof(IApplicationRepository))
+        if (repositoryType == typeof(IAppRepository))
+        {
+            return To<RepositoryType>(new AppRepository(_dbContext));
+        }
+        else if (repositoryType == typeof(IApplicationRepository))
         {
             return To<RepositoryType>(new ApplicationRepository(_dbContext));
+        }
+        else if (repositoryType == typeof(ICompanyAssignedAppsRepository))
+        {
+            return To<RepositoryType>(new CompanyAssignedAppsRepository(_dbContext));
+        }
+        else if (repositoryType == typeof(ICompanyRepository))
+        {
+            return To<RepositoryType>(new CompanyRepository(_dbContext));
         }
         else if (repositoryType == typeof(IConnectorsRepository))
         {
             return To<RepositoryType>(new ConnectorsRepository(_dbContext));
+        }
+        else if (repositoryType == typeof(IIdentityProviderRepository))
+        {
+            return To<RepositoryType>(new IdentityProviderRepository(_dbContext));
         }
         else if (repositoryType == typeof(IServiceAccountsRepository))
         {

--- a/src/portalbackend/CatenaX.NetworkServices.PortalBackend.DBAccess/Repositories/AppRepository.cs
+++ b/src/portalbackend/CatenaX.NetworkServices.PortalBackend.DBAccess/Repositories/AppRepository.cs
@@ -54,4 +54,11 @@ public class AppRepository : IAppRepository
 
         return (appName: appDetails.Name!, providerName: appDetails.Provider!, providerContactEmail: appDetails.ContactEmail!);
     }
+
+    /// <inheritdoc/>
+    public Task<string?> GetAppAssignedClientIdUntrackedAsync(Guid appId) =>
+        _context.AppAssignedClients.AsNoTracking()
+            .Where(appClient => appClient.AppId == appId)
+            .Select(appClient => appClient.IamClient!.ClientClientId)
+            .SingleOrDefaultAsync();
 }

--- a/src/portalbackend/CatenaX.NetworkServices.PortalBackend.DBAccess/Repositories/ApplicationRepository.cs
+++ b/src/portalbackend/CatenaX.NetworkServices.PortalBackend.DBAccess/Repositories/ApplicationRepository.cs
@@ -16,6 +16,23 @@ public class ApplicationRepository : IApplicationRepository
         _dbContext = portalDbContext;
     }
 
+    public CompanyApplication CreateCompanyApplication(Company company, CompanyApplicationStatusId companyApplicationStatusId) =>
+        _dbContext.CompanyApplications.Add(
+            new CompanyApplication(
+                Guid.NewGuid(),
+                company.Id,
+                companyApplicationStatusId,
+                DateTimeOffset.UtcNow)).Entity;
+
+    public Invitation CreateInvitation(Guid applicationId, CompanyUser user) =>
+        _dbContext.Invitations.Add(
+            new Invitation(
+                Guid.NewGuid(),
+                applicationId,
+                user.Id,
+                InvitationStatusId.CREATED,
+                DateTimeOffset.UtcNow)).Entity;
+
     public Task<CompanyWithAddress?> GetCompanyWithAdressUntrackedAsync(Guid companyApplicationId) =>
         _dbContext.CompanyApplications
             .Where(companyApplication => companyApplication.Id == companyApplicationId)

--- a/src/portalbackend/CatenaX.NetworkServices.PortalBackend.DBAccess/Repositories/CompanyRepository.cs
+++ b/src/portalbackend/CatenaX.NetworkServices.PortalBackend.DBAccess/Repositories/CompanyRepository.cs
@@ -1,5 +1,6 @@
 ﻿using CatenaX.NetworkServices.PortalBackend.PortalEntities;
 using CatenaX.NetworkServices.PortalBackend.PortalEntities.Entities;
+using CatenaX.NetworkServices.PortalBackend.PortalEntities.Enums;
 
 namespace CatenaX.NetworkServices.PortalBackend.DBAccess.Repositories;
 
@@ -14,12 +15,19 @@ public class CompanyRepository : ICompanyRepository
     /// <param name="portalDbContext">Portal DB context.</param>
     public CompanyRepository(PortalDbContext portalDbContext)
     {
-        this._context = portalDbContext;
+        _context = portalDbContext;
     }
 
     /// <inheritdoc/>
-    public ValueTask<Company?> GetCompanyByIdAsync(Guid companyId)
-    {
-        return this._context.Companies.FindAsync(companyId);
-    }
+    public Company CreateCompany(string companyName) =>
+        _context.Companies.Add(
+            new Company(
+                Guid.NewGuid(),
+                companyName,
+                CompanyStatusId.PENDING,
+                DateTimeOffset.UtcNow)).Entity;
+
+    /// <inheritdoc/>
+    public ValueTask<Company?> GetCompanyByIdAsync(Guid companyId) =>
+        _context.Companies.FindAsync(companyId);
 }

--- a/src/portalbackend/CatenaX.NetworkServices.PortalBackend.DBAccess/Repositories/IAppRepository.cs
+++ b/src/portalbackend/CatenaX.NetworkServices.PortalBackend.DBAccess/Repositories/IAppRepository.cs
@@ -18,4 +18,11 @@ public interface IAppRepository
     /// <param name="appId">ID of the app.</param>
     /// <returns>Tuple of provider company details.</returns>
     public Task<(string appName, string providerName, string providerContactEmail)> GetAppProviderDetailsAsync(Guid appId);
+
+    /// <summary>
+    /// Get Client Name by App Id
+    /// </summary>
+    /// <param name="appId"></param>
+    /// <returns>Client Name</returns>
+    Task<string?> GetAppAssignedClientIdUntrackedAsync(Guid appId);
 }

--- a/src/portalbackend/CatenaX.NetworkServices.PortalBackend.DBAccess/Repositories/IApplicationRepository.cs
+++ b/src/portalbackend/CatenaX.NetworkServices.PortalBackend.DBAccess/Repositories/IApplicationRepository.cs
@@ -1,11 +1,14 @@
 using CatenaX.NetworkServices.Framework.Models;
 using CatenaX.NetworkServices.PortalBackend.DBAccess.Models;
 using CatenaX.NetworkServices.PortalBackend.PortalEntities.Entities;
+using CatenaX.NetworkServices.PortalBackend.PortalEntities.Enums;
 
 namespace CatenaX.NetworkServices.PortalBackend.DBAccess.Repositories;
 
 public interface IApplicationRepository
 {
+    CompanyApplication CreateCompanyApplication(Company company, CompanyApplicationStatusId companyApplicationStatusId);
+    Invitation CreateInvitation(Guid applicationId, CompanyUser user);
     Task<CompanyWithAddress?> GetCompanyWithAdressUntrackedAsync(Guid companyApplicationId);
     Pagination.AsyncSource<CompanyApplicationDetails> GetCompanyApplicationDetailsUntrackedAsync(int skip, int take);
     Task<CompanyApplication?> GetCompanyAndApplicationForSubmittedApplication(Guid applicationId);

--- a/src/portalbackend/CatenaX.NetworkServices.PortalBackend.DBAccess/Repositories/ICompanyAssignedAppsRepository.cs
+++ b/src/portalbackend/CatenaX.NetworkServices.PortalBackend.DBAccess/Repositories/ICompanyAssignedAppsRepository.cs
@@ -1,5 +1,4 @@
-﻿using CatenaX.NetworkServices.PortalBackend.PortalEntities.Entities;
-using CatenaX.NetworkServices.PortalBackend.PortalEntities.Enums;
+﻿using CatenaX.NetworkServices.PortalBackend.PortalEntities.Enums;
 
 namespace CatenaX.NetworkServices.PortalBackend.DBAccess.Repositories;
 

--- a/src/portalbackend/CatenaX.NetworkServices.PortalBackend.DBAccess/Repositories/ICompanyRepository.cs
+++ b/src/portalbackend/CatenaX.NetworkServices.PortalBackend.DBAccess/Repositories/ICompanyRepository.cs
@@ -8,9 +8,16 @@ namespace CatenaX.NetworkServices.PortalBackend.DBAccess.Repositories;
 public interface ICompanyRepository
 {
     /// <summary>
+    /// Creates new company entity from persistence layer.
+    /// </summary>
+    /// <param name="companyName">Name of the company to create the new entity for.</param>
+    /// <returns>Created company entity.</returns>
+    Company CreateCompany(string companyName);
+
+    /// <summary>
     /// Retrieves company entity from persistence layer.
     /// </summary>
     /// <param name="companyId">Id of the company to retrieve.</param>
     /// <returns>Requested company entity or null if it does not exist.</returns>
-    public ValueTask<Company?> GetCompanyByIdAsync(Guid companyId);
+    ValueTask<Company?> GetCompanyByIdAsync(Guid companyId);
 }

--- a/src/portalbackend/CatenaX.NetworkServices.PortalBackend.DBAccess/Repositories/IIdentityProviderRepository.cs
+++ b/src/portalbackend/CatenaX.NetworkServices.PortalBackend.DBAccess/Repositories/IIdentityProviderRepository.cs
@@ -1,0 +1,11 @@
+using CatenaX.NetworkServices.PortalBackend.PortalEntities.Entities;
+namespace CatenaX.NetworkServices.PortalBackend.DBAccess.Repositories;
+
+/// <summary>
+/// Repository for User Management on persistence layer.
+/// </summary>
+public interface IIdentityProviderRepository
+{
+    IdentityProvider CreateSharedIdentityProvider(Company company);
+    IamIdentityProvider CreateIamIdentityProvider(IdentityProvider identityProvider, string idpAlias);
+}

--- a/src/portalbackend/CatenaX.NetworkServices.PortalBackend.DBAccess/Repositories/IUserRepository.cs
+++ b/src/portalbackend/CatenaX.NetworkServices.PortalBackend.DBAccess/Repositories/IUserRepository.cs
@@ -1,3 +1,5 @@
+using CatenaX.NetworkServices.PortalBackend.PortalEntities.Entities;
+using CatenaX.NetworkServices.PortalBackend.PortalEntities.Enums;
 using CatenaX.NetworkServices.PortalBackend.DBAccess.Models;
 namespace CatenaX.NetworkServices.PortalBackend.DBAccess.Repositories;
 
@@ -6,6 +8,8 @@ namespace CatenaX.NetworkServices.PortalBackend.DBAccess.Repositories;
 /// </summary>
 public interface IUserRepository
 {
+    CompanyUser CreateCompanyUser(string? firstName, string? lastName, string email, Guid companyId, CompanyUserStatusId companyUserStatusId);
+    IamUser CreateIamUser(CompanyUser companyUser, string iamUserId);
     Task<CompanyUserDetails?> GetOwnCompanyUserDetailsUntrackedAsync(Guid companyUserId, string iamUserId);
     Task<CompanyUserBusinessPartners?> GetOwnCompanyUserWithAssignedBusinessPartnerNumbersUntrackedAsync(Guid companyUserId, string adminUserId);
     Task<Guid> GetCompanyIdForIamUserUntrackedAsync(string iamUserId);
@@ -16,14 +20,8 @@ public interface IUserRepository
     /// <param name="companyUserId"></param>
     /// <param name="adminUserId"></param>
     /// <returns>Company and IamUser</returns>
-    Task<CompanyIamUser> GetIdpUserByIdAsync(Guid companyUserId, string adminUserId);
+    Task<CompanyIamUser?> GetIdpUserByIdUntrackedAsync(Guid companyUserId, string adminUserId);
 
-    /// <summary>
-    /// Get Client Name by App Id
-    /// </summary>
-    /// <param name="appId"></param>
-    /// <returns>Client Name</returns>
-    Task<string> GetAppAssignedRolesClientIdAsync(Guid appId);
     public Task<CompanyUserDetails?> GetUserDetailsUntrackedAsync(string iamUserId);
     Task<CompanyUserWithIdpBusinessPartnerData?> GetUserWithCompanyIdpAsync(string iamUserId);
     Task<CompanyUserWithIdpData?> GetUserWithIdpAsync(string iamUserId);

--- a/src/portalbackend/CatenaX.NetworkServices.PortalBackend.DBAccess/Repositories/IdentityProviderRepository.cs
+++ b/src/portalbackend/CatenaX.NetworkServices.PortalBackend.DBAccess/Repositories/IdentityProviderRepository.cs
@@ -1,0 +1,39 @@
+﻿using CatenaX.NetworkServices.PortalBackend.PortalEntities;
+using CatenaX.NetworkServices.PortalBackend.PortalEntities.Entities;
+using CatenaX.NetworkServices.PortalBackend.PortalEntities.Enums;
+
+namespace CatenaX.NetworkServices.PortalBackend.DBAccess.Repositories;
+
+/// <inheritdoc/>
+public class IdentityProviderRepository : IIdentityProviderRepository
+{
+    private readonly PortalDbContext _context;
+
+    /// <summary>
+    /// Constructor.
+    /// </summary>
+    /// <param name="portalDbContext">Portal DB context.</param>
+    public IdentityProviderRepository(PortalDbContext portalDbContext)
+    {
+        _context = portalDbContext;
+    }
+
+    /// <inheritdoc/>
+    public IdentityProvider CreateSharedIdentityProvider(Company company)
+    {
+        var idp = new IdentityProvider(
+            Guid.NewGuid(),
+            IdentityProviderCategoryId.KEYCLOAK_SHARED,
+            DateTimeOffset.UtcNow);
+        idp.Companies.Add(company);
+        return _context.IdentityProviders.Add(idp).Entity;
+    }
+
+    /// <inheritdoc/>
+
+    public IamIdentityProvider CreateIamIdentityProvider(IdentityProvider identityProvider, string idpAlias) =>
+        _context.IamIdentityProviders.Add(
+            new IamIdentityProvider(
+                idpAlias,
+                identityProvider.Id)).Entity;
+}


### PR DESCRIPTION
Did fix repository-usage in recently merged implementation of CPLP-466 (add app user role to own company user) also fixing the nullability-issues that were not detected in review.

To remove the remaining reference to IPortalBackendDBAccess.GetUserRoleIdsUntrackedAsync I also refactored the invite-service.
