### PR TITLE
CPLP-1040 reimplement double user check fixing CPLP-1116

### DIFF
--- a/src/administration/CatenaX.NetworkServices.Administration.Service/BusinessLogic/UserBusinessLogic.cs
+++ b/src/administration/CatenaX.NetworkServices.Administration.Service/BusinessLogic/UserBusinessLogic.cs
@@ -187,14 +187,24 @@ namespace CatenaX.NetworkServices.Administration.Service.BusinessLogic
             {
                 throw new ArgumentNullException("not all of userEntityId, companyUserId, firstName, lastName, email, status may be null");
             }
-            return _portalDBAccess.GetCompanyUserDetailsUntrackedAsync(
+            return _portalRepositories.GetInstance<IUserRepository>().GetOwnCompanyUserQuery(
                 adminUserId,
                 companyUserId,
                 userEntityId,
                 firstName,
                 lastName,
                 email,
-                status);
+                status)
+                .AsNoTracking()
+                .Select(companyUser => new CompanyUserData(
+                    companyUser.Id,
+                    companyUser.CompanyUserStatusId)
+                {
+                    FirstName = companyUser.Firstname,
+                    LastName = companyUser.Lastname,
+                    Email = companyUser.Email
+                })
+                .AsAsyncEnumerable();
         }
 
         public async IAsyncEnumerable<ClientRoles> GetClientRolesAsync(Guid appId, string? languageShortName = null)

--- a/src/portalbackend/CatenaX.NetworkServices.PortalBackend.DBAccess/IPortalBackendDBAccess.cs
+++ b/src/portalbackend/CatenaX.NetworkServices.PortalBackend.DBAccess/IPortalBackendDBAccess.cs
@@ -8,8 +8,6 @@ namespace CatenaX.NetworkServices.PortalBackend.DBAccess
     {
         [Obsolete("use IUserRepository instead")]
         CompanyUser CreateCompanyUser(string? firstName, string? lastName, string email, Guid companyId, CompanyUserStatusId companyUserStatusId);
-        [Obsolete("use IApplicationRepository instead")]
-        Invitation CreateInvitation(Guid applicationId, CompanyUser user);
         [Obsolete("use IUserRolesRepository instead")]
         CompanyUserAssignedRole CreateCompanyUserAssignedRole(Guid companyUserId, Guid companyUserRoleId);
         [Obsolete("use IUserRepository instead")]
@@ -19,11 +17,9 @@ namespace CatenaX.NetworkServices.PortalBackend.DBAccess
         CompanyAssignedRole CreateCompanyAssignedRole(Guid companyId, CompanyRoleId companyRoleId);
         IAsyncEnumerable<CompanyApplicationWithStatus> GetApplicationsWithStatusUntrackedAsync(string iamUserId);
         Task<Company?> GetCompanyWithAdressAsync(Guid companyApplicationId, Guid companyId);
-        Task<CompanyNameIdIdpAlias?> GetCompanyNameIdWithSharedIdpAliasUntrackedAsync(Guid companyApplicationId, string iamUserId);
         Task<CompanyNameBpnIdpAlias?> GetCompanyNameIdpAliasUntrackedAsync(string iamUserId);
         Task<string?> GetSharedIdentityProviderIamAliasUntrackedAsync(string iamUserId);
         IAsyncEnumerable<CompanyUser> GetCompanyUserRolesIamUsersAsync(IEnumerable<Guid> companyUserIds, string iamUser);
-        IAsyncEnumerable<CompanyUserData> GetCompanyUserDetailsUntrackedAsync(string adminUserId, Guid? companyUserId = null, string? userEntityId = null, string? firstName = null, string? lastName = null, string? email = null, CompanyUserStatusId? companyUserStatusId = null);
         Task<CompanyApplication?> GetCompanyApplicationAsync(Guid applicationId);
         Task<CompanyApplicationStatusId> GetApplicationStatusUntrackedAsync(Guid applicationId);
         IAsyncEnumerable<AgreementsAssignedCompanyRoleData> GetAgreementAssignedCompanyRolesUntrackedAsync(IEnumerable<CompanyRoleId> companyRoleIds);
@@ -34,13 +30,13 @@ namespace CatenaX.NetworkServices.PortalBackend.DBAccess
         IamUser RemoveIamUser(IamUser iamUser);
         IAsyncEnumerable<CompanyRoleData> GetCompanyRoleAgreementsUntrackedAsync();
         IAsyncEnumerable<AgreementData> GetAgreementsUntrackedAsync();
+        [Obsolete("user IUserRolesRepository instead")]
         IAsyncEnumerable<UserRoleWithId> GetUserRoleWithIdsUntrackedAsync(string clientClientId, IEnumerable<string> companyUserRoles);
         IAsyncEnumerable<InvitedUserDetail> GetInvitedUserDetailsUntrackedAsync(Guid applicationId);
         Task<IdpUser?> GetIdpCategoryIdByUserIdAsync(Guid companyUserId, string adminUserId);
         IAsyncEnumerable<UploadDocuments> GetUploadedDocumentsAsync(Guid applicationId, DocumentTypeId documentTypeId, string iamUserId);
         Task<Invitation?> GetInvitationStatusAsync(string iamUserId);
         Task<RegistrationData?> GetRegistrationDataUntrackedAsync(Guid applicationId, string iamUserId);
-        Task<bool> IsUserExisting(string iamUserId);
         IAsyncEnumerable<ClientRoles> GetClientRolesAsync(Guid appId, string? languageShortName = null);
         Task<string?> GetLanguageAsync(string LanguageShortName);
         Task<Guid> GetAppAssignedClientsAsync(Guid appId);        

--- a/src/portalbackend/CatenaX.NetworkServices.PortalBackend.DBAccess/PortalBackendDBAccess.cs
+++ b/src/portalbackend/CatenaX.NetworkServices.PortalBackend.DBAccess/PortalBackendDBAccess.cs
@@ -31,16 +31,6 @@ namespace CatenaX.NetworkServices.PortalBackend.DBAccess
                     Email = email,
                 }).Entity;
 
-        [Obsolete("user IApplicationRepository instead")]
-        public Invitation CreateInvitation(Guid applicationId, CompanyUser user) =>
-            _dbContext.Invitations.Add(
-                new Invitation(
-                    Guid.NewGuid(),
-                    applicationId,
-                    user.Id,
-                    InvitationStatusId.CREATED,
-                    DateTimeOffset.UtcNow)).Entity;
-
         [Obsolete("use IUserRolesRepository instead")]
         public CompanyUserAssignedRole CreateCompanyUserAssignedRole(Guid companyUserId, Guid userRoleId) =>
             _dbContext.CompanyUserAssignedRoles.Add(
@@ -106,24 +96,6 @@ namespace CatenaX.NetworkServices.PortalBackend.DBAccess
                 .Where(company => company.Id == companyId && company.CompanyApplications.Any(application => application.Id == companyApplicationId))
                 .SingleOrDefaultAsync();
 
-        public Task<CompanyNameIdIdpAlias?> GetCompanyNameIdWithSharedIdpAliasUntrackedAsync(Guid applicationId, string iamUserId) =>
-            _dbContext.IamUsers
-                .AsNoTracking()
-                .Where(iamUser =>
-                    iamUser.UserEntityId == iamUserId
-                    && iamUser.CompanyUser!.Company!.CompanyApplications.Any(application => application.Id == applicationId))
-                .Select(iamUser => iamUser.CompanyUser!.Company)
-                .Select(company => new CompanyNameIdIdpAlias(
-                        company!.Name,
-                        company.Id)
-                {
-                    IdpAlias = company.IdentityProviders
-                            .Where(identityProvider => identityProvider.IdentityProviderCategoryId == IdentityProviderCategoryId.KEYCLOAK_SHARED)
-                            .Select(identityProvider => identityProvider.IamIdentityProvider!.IamIdpAlias)
-                            .SingleOrDefault()
-                })
-                .SingleOrDefaultAsync();
-
         public Task<CompanyNameBpnIdpAlias?> GetCompanyNameIdpAliasUntrackedAsync(string iamUserId) =>
             _dbContext.IamUsers
                 .AsNoTracking()
@@ -155,35 +127,6 @@ namespace CatenaX.NetworkServices.PortalBackend.DBAccess
                 .Where(companyUser => companyUserIds.Contains(companyUser.Id) && companyUser.IamUser!.UserEntityId != null)
                 .Include(companyUser => companyUser.CompanyUserAssignedRoles)
                 .Include(companyUser => companyUser.IamUser)
-                .AsAsyncEnumerable();
-
-        public IAsyncEnumerable<CompanyUserData> GetCompanyUserDetailsUntrackedAsync(
-            string adminUserId,
-            Guid? companyUserId = null,
-            string? userEntityId = null,
-            string? firstName = null,
-            string? lastName = null,
-            string? email = null,
-            CompanyUserStatusId? status = null) =>
-            _dbContext.CompanyUsers
-                .AsNoTracking()
-                .Where(companyUser => companyUser.IamUser!.UserEntityId == adminUserId)
-                .SelectMany(companyUser => companyUser.Company!.CompanyUsers)
-                .Where(companyUser =>
-                    userEntityId != null ? companyUser.IamUser!.UserEntityId == userEntityId : true
-                    && companyUserId.HasValue ? companyUser.Id == companyUserId!.Value : true
-                    && firstName != null ? companyUser.Firstname == firstName : true
-                    && lastName != null ? companyUser.Lastname == lastName : true
-                    && email != null ? companyUser.Email == email : true
-                    && status.HasValue ? companyUser.CompanyUserStatusId == status : true)
-                .Select(companyUser => new CompanyUserData(
-                    companyUser.Id,
-                    companyUser.CompanyUserStatusId)
-                {
-                    FirstName = companyUser.Firstname,
-                    LastName = companyUser.Lastname,
-                    Email = companyUser.Email
-                })
                 .AsAsyncEnumerable();
 
         public Task<CompanyApplication?> GetCompanyApplicationAsync(Guid applicationId) =>
@@ -272,6 +215,7 @@ namespace CatenaX.NetworkServices.PortalBackend.DBAccess
         public IamUser RemoveIamUser(IamUser iamUser) =>
             _dbContext.Remove(iamUser).Entity;
 
+        [Obsolete("user IUserRolesRepository instead")]
         public IAsyncEnumerable<UserRoleWithId> GetUserRoleWithIdsUntrackedAsync(string clientClientId, IEnumerable<string> userRoles) =>
             _dbContext.UserRoles
                 .AsNoTracking()
@@ -356,11 +300,6 @@ namespace CatenaX.NetworkServices.PortalBackend.DBAccess
                    CountryDe = company.Address.Country!.CountryNameDe,
                    TaxId = company.TaxId
                }).SingleOrDefaultAsync();
-
-        public Task<bool> IsUserExisting(string iamUserId) =>
-            _dbContext.IamUsers
-                .AsNoTracking()
-                .AnyAsync(iamUser => iamUser.UserEntityId == iamUserId);
 
         public IAsyncEnumerable<ClientRoles> GetClientRolesAsync(Guid appId, string? languageShortName = null) =>
            _dbContext.AppAssignedClients

--- a/src/portalbackend/CatenaX.NetworkServices.PortalBackend.DBAccess/Repositories/CompanyRepository.cs
+++ b/src/portalbackend/CatenaX.NetworkServices.PortalBackend.DBAccess/Repositories/CompanyRepository.cs
@@ -1,6 +1,8 @@
-﻿using CatenaX.NetworkServices.PortalBackend.PortalEntities;
+﻿using CatenaX.NetworkServices.PortalBackend.DBAccess.Models;
+using CatenaX.NetworkServices.PortalBackend.PortalEntities;
 using CatenaX.NetworkServices.PortalBackend.PortalEntities.Entities;
 using CatenaX.NetworkServices.PortalBackend.PortalEntities.Enums;
+using Microsoft.EntityFrameworkCore;
 
 namespace CatenaX.NetworkServices.PortalBackend.DBAccess.Repositories;
 
@@ -30,4 +32,22 @@ public class CompanyRepository : ICompanyRepository
     /// <inheritdoc/>
     public ValueTask<Company?> GetCompanyByIdAsync(Guid companyId) =>
         _context.Companies.FindAsync(companyId);
+
+    public Task<CompanyNameIdIdpAlias?> GetCompanyNameIdWithSharedIdpAliasUntrackedAsync(Guid applicationId, string iamUserId) =>
+        _context.IamUsers
+            .AsNoTracking()
+            .Where(iamUser =>
+                iamUser.UserEntityId == iamUserId
+                && iamUser.CompanyUser!.Company!.CompanyApplications.Any(application => application.Id == applicationId))
+            .Select(iamUser => iamUser.CompanyUser!.Company)
+            .Select(company => new CompanyNameIdIdpAlias(
+                    company!.Name,
+                    company.Id)
+            {
+                IdpAlias = company.IdentityProviders
+                        .Where(identityProvider => identityProvider.IdentityProviderCategoryId == IdentityProviderCategoryId.KEYCLOAK_SHARED)
+                        .Select(identityProvider => identityProvider.IamIdentityProvider!.IamIdpAlias)
+                        .SingleOrDefault()
+            })
+            .SingleOrDefaultAsync();
 }

--- a/src/portalbackend/CatenaX.NetworkServices.PortalBackend.DBAccess/Repositories/ICompanyRepository.cs
+++ b/src/portalbackend/CatenaX.NetworkServices.PortalBackend.DBAccess/Repositories/ICompanyRepository.cs
@@ -1,4 +1,5 @@
 ﻿using CatenaX.NetworkServices.PortalBackend.PortalEntities.Entities;
+using CatenaX.NetworkServices.PortalBackend.DBAccess.Models;
 
 namespace CatenaX.NetworkServices.PortalBackend.DBAccess.Repositories;
 
@@ -20,4 +21,6 @@ public interface ICompanyRepository
     /// <param name="companyId">Id of the company to retrieve.</param>
     /// <returns>Requested company entity or null if it does not exist.</returns>
     ValueTask<Company?> GetCompanyByIdAsync(Guid companyId);
+
+    Task<CompanyNameIdIdpAlias?> GetCompanyNameIdWithSharedIdpAliasUntrackedAsync(Guid applicationId, string iamUserId);
 }

--- a/src/portalbackend/CatenaX.NetworkServices.PortalBackend.DBAccess/Repositories/IUserRepository.cs
+++ b/src/portalbackend/CatenaX.NetworkServices.PortalBackend.DBAccess/Repositories/IUserRepository.cs
@@ -10,6 +10,8 @@ public interface IUserRepository
 {
     CompanyUser CreateCompanyUser(string? firstName, string? lastName, string email, Guid companyId, CompanyUserStatusId companyUserStatusId);
     IamUser CreateIamUser(CompanyUser companyUser, string iamUserId);
+    IQueryable<CompanyUser> GetOwnCompanyUserQuery(string adminUserId, Guid? companyUserId = null, string? userEntityId = null, string? firstName = null, string? lastName = null, string? email = null, CompanyUserStatusId? status = null);
+    Task<bool> IsOwnCompanyUserWithEmailExisting(string email, string adminUserId);
     Task<CompanyUserDetails?> GetOwnCompanyUserDetailsUntrackedAsync(Guid companyUserId, string iamUserId);
     Task<CompanyUserBusinessPartners?> GetOwnCompanyUserWithAssignedBusinessPartnerNumbersUntrackedAsync(Guid companyUserId, string adminUserId);
     Task<Guid> GetCompanyIdForIamUserUntrackedAsync(string iamUserId);

--- a/src/portalbackend/CatenaX.NetworkServices.PortalBackend.DBAccess/Repositories/IUserRolesRepository.cs
+++ b/src/portalbackend/CatenaX.NetworkServices.PortalBackend.DBAccess/Repositories/IUserRolesRepository.cs
@@ -8,4 +8,5 @@ public interface IUserRolesRepository
     CompanyUserAssignedRole CreateCompanyUserAssignedRole(Guid companyUserId, Guid companyUserRoleId);
     IAsyncEnumerable<UserRoleData> GetUserRoleDataUntrackedAsync(IEnumerable<Guid> userRoleIds);
     IAsyncEnumerable<Guid> GetUserRoleIdsUntrackedAsync(IDictionary<string, IEnumerable<string>> clientRoles);
+    IAsyncEnumerable<UserRoleWithId> GetUserRoleWithIdsUntrackedAsync(string clientClientId, IEnumerable<string> userRoles);
 }

--- a/src/portalbackend/CatenaX.NetworkServices.PortalBackend.DBAccess/Repositories/UserRepository.cs
+++ b/src/portalbackend/CatenaX.NetworkServices.PortalBackend.DBAccess/Repositories/UserRepository.cs
@@ -39,6 +39,31 @@ public class UserRepository : IUserRepository
                 iamUserEntityId,
                 user.Id)).Entity;
 
+    public IQueryable<CompanyUser> GetOwnCompanyUserQuery(
+        string adminUserId,
+        Guid? companyUserId = null,
+        string? userEntityId = null,
+        string? firstName = null,
+        string? lastName = null,
+        string? email = null,
+        CompanyUserStatusId? status = null) =>
+            _dbContext.CompanyUsers
+                .Where(companyUser => companyUser.IamUser!.UserEntityId == adminUserId)
+                .SelectMany(companyUser => companyUser.Company!.CompanyUsers)
+                .Where(companyUser =>
+                    userEntityId != null ? companyUser.IamUser!.UserEntityId == userEntityId : true
+                    && companyUserId.HasValue ? companyUser.Id == companyUserId!.Value : true
+                    && firstName != null ? companyUser.Firstname == firstName : true
+                    && lastName != null ? companyUser.Lastname == lastName : true
+                    && email != null ? companyUser.Email == email : true
+                    && status.HasValue ? companyUser.CompanyUserStatusId == status : true);
+
+    public Task<bool> IsOwnCompanyUserWithEmailExisting(string email, string adminUserId) =>
+        _dbContext.IamUsers
+            .Where(iamUser => iamUser.UserEntityId == adminUserId)
+            .SelectMany(iamUser => iamUser.CompanyUser!.Company!.CompanyUsers)
+            .AnyAsync(companyUser => companyUser!.Email == email);
+
     public Task<CompanyUserDetails?> GetOwnCompanyUserDetailsUntrackedAsync(Guid companyUserId, string iamUserId) =>
         _dbContext.CompanyUsers
             .AsNoTracking()

--- a/src/portalbackend/CatenaX.NetworkServices.PortalBackend.DBAccess/Repositories/UserRolesRepository.cs
+++ b/src/portalbackend/CatenaX.NetworkServices.PortalBackend.DBAccess/Repositories/UserRolesRepository.cs
@@ -46,4 +46,15 @@ public class UserRolesRepository : IUserRolesRepository
             }
         }
     }
+
+    public IAsyncEnumerable<UserRoleWithId> GetUserRoleWithIdsUntrackedAsync(string clientClientId, IEnumerable<string> userRoles) =>
+        _dbContext.UserRoles
+            .AsNoTracking()
+            .Where(userRole => userRole.IamClient!.ClientClientId == clientClientId && userRoles.Contains(userRole.UserRoleText))
+            .AsQueryable()
+            .Select(userRole => new UserRoleWithId(
+                userRole.UserRoleText,
+                userRole.Id
+            ))
+            .AsAsyncEnumerable();
 }


### PR DESCRIPTION
implements fix for https://jira.catena-x.net/browse/CPLP-1116

initial implementation of CPLP-1040 invite user double user check ( https://jira.catena-x.net/browse/CPLP-1040 ) was actually checking whether the logged in user (from the token) already exists in table iam_users. As long the currently logged in user was created accordingly this condition will always be true.
New implementation as of this PR checks whether in the company of the currently logged in user a user with the same email-address as the to-be-created user already does exist.
(new implementation includes refactoring of business-method to repository-pattern)