### PR TITLE
Feature/cplp 1151 revert cleanup removing redundancy in userdetailselection

### DIFF
--- a/src/portalbackend/CatenaX.NetworkServices.PortalBackend.DBAccess/Repositories/UserRepository.cs
+++ b/src/portalbackend/CatenaX.NetworkServices.PortalBackend.DBAccess/Repositories/UserRepository.cs
@@ -91,7 +91,28 @@ public class UserRepository : IUserRepository
                                   && companyUser.CompanyUserStatusId == CompanyUserStatusId.ACTIVE
                                   && companyUser.Company!.CompanyUsers.Any(companyUser =>
                                       companyUser.IamUser!.UserEntityId == iamUserId))
-            .Select(companyUser => SelectCompanyUserDetails(companyUser))
+            .Select(companyUser => new CompanyUserDetails(
+                companyUser.Id,
+                companyUser.DateCreated,
+                companyUser.CompanyUserAssignedBusinessPartners.Select(assignedPartner =>
+                    assignedPartner.BusinessPartnerNumber),
+                companyUser.Company!.Name,
+                companyUser.CompanyUserStatusId,
+                companyUser.Company!.CompanyAssignedApps
+                    .Where(app => app.AppSubscriptionStatusId == AppSubscriptionStatusId.ACTIVE)
+                    .Select(app => new CompanyUserAssignedRoleDetails(
+                        app.AppId,
+                        app.App.IamClients
+                        .SelectMany(iamClient => iamClient.UserRoles
+                            .Where(role => role.CompanyUsers.Any(user => user.Id == companyUser.Id))
+                            .Select(role => role.UserRoleText))
+                    ))
+                    )
+            {
+                FirstName = companyUser.Firstname,
+                LastName = companyUser.Lastname,
+                Email = companyUser.Email
+            })
             .SingleOrDefaultAsync();
 
     public Task<CompanyUserBusinessPartners?> GetOwnCompanyUserWithAssignedBusinessPartnerNumbersUntrackedAsync(
@@ -150,7 +171,28 @@ public class UserRepository : IUserRepository
         _dbContext.CompanyUsers
             .AsNoTracking()
             .Where(companyUser => companyUser.IamUser!.UserEntityId == iamUserId)
-            .Select(companyUser => SelectCompanyUserDetails(companyUser))
+            .Select(companyUser => new CompanyUserDetails(
+                companyUser.Id,
+                companyUser.DateCreated,
+                companyUser.CompanyUserAssignedBusinessPartners.Select(assignedPartner =>
+                    assignedPartner.BusinessPartnerNumber),
+                companyUser.Company!.Name,
+                companyUser.CompanyUserStatusId,
+                companyUser.Company!.CompanyAssignedApps
+                    .Where(app => app.AppSubscriptionStatusId == AppSubscriptionStatusId.ACTIVE)
+                    .Select(app => new CompanyUserAssignedRoleDetails(
+                        app.AppId,
+                        app.App.IamClients
+                        .SelectMany(iamClient => iamClient.UserRoles
+                            .Where(role => role.CompanyUsers.Any(user => user.Id == companyUser.Id))
+                            .Select(role => role.UserRoleText))
+                    ))
+                    )
+            {
+                FirstName = companyUser.Firstname,
+                LastName = companyUser.Lastname,
+                Email = companyUser.Email
+            })
             .SingleOrDefaultAsync();
 
     public Task<CompanyUserWithIdpBusinessPartnerData?> GetUserWithCompanyIdpAsync(string iamUserId) =>
@@ -171,7 +213,15 @@ public class UserRepository : IUserRepository
                     .SingleOrDefault()!,
                 companyUser.CompanyUserAssignedBusinessPartners.Select(assignedPartner =>
                     assignedPartner.BusinessPartnerNumber),
-                SelectCompanyUserAssignedRoleDetails(companyUser)))
+                companyUser.Company!.CompanyAssignedApps
+                    .Where(app => app.AppSubscriptionStatusId == AppSubscriptionStatusId.ACTIVE)
+                    .Select(app => new CompanyUserAssignedRoleDetails(
+                        app.AppId,
+                        app.App.IamClients
+                        .SelectMany(iamClient => iamClient.UserRoles
+                            .Where(role => role.CompanyUsers.Any(user => user.Id == companyUser.Id))
+                            .Select(role => role.UserRoleText))
+                    ))))
             .SingleOrDefaultAsync();
 
     public Task<CompanyUserWithIdpData?> GetUserWithIdpAsync(string iamUserId) =>
@@ -239,30 +289,4 @@ public class UserRepository : IUserRepository
         _dbContext.CompanyUsers.Where(x => x.IamUser!.UserEntityId == iamUserId || x.Id == companyUserId)
             .Select(companyUser => ((Guid CompanyUserId, bool IsIamUser)) new (companyUser.Id, companyUser.IamUser!.UserEntityId == iamUserId))
             .ToAsyncEnumerable();
-
-    private static CompanyUserDetails SelectCompanyUserDetails(CompanyUser companyUser) =>
-        new CompanyUserDetails(
-            companyUser.Id,
-            companyUser.DateCreated,
-            companyUser.CompanyUserAssignedBusinessPartners.Select(assignedPartner =>
-                assignedPartner.BusinessPartnerNumber),
-            companyUser.Company!.Name,
-            companyUser.CompanyUserStatusId,
-            SelectCompanyUserAssignedRoleDetails(companyUser))
-        {
-            FirstName = companyUser.Firstname,
-            LastName = companyUser.Lastname,
-            Email = companyUser.Email
-        };
-
-    private static IEnumerable<CompanyUserAssignedRoleDetails> SelectCompanyUserAssignedRoleDetails(CompanyUser companyUser) =>
-        companyUser.Company!.CompanyAssignedApps
-        .Where(app => app.AppSubscriptionStatusId == AppSubscriptionStatusId.ACTIVE)
-        .Select(app => new CompanyUserAssignedRoleDetails(
-            app.AppId,
-            app.App!.IamClients
-            .SelectMany(iamClient => iamClient.UserRoles
-                .Where(role => role.CompanyUsers.Any(user => user.Id == companyUser.Id))
-                .Select(role => role.UserRoleText))
-        ));
 }

--- a/src/portalbackend/CatenaX.NetworkServices.PortalBackend.DBAccess/Repositories/UserRepository.cs
+++ b/src/portalbackend/CatenaX.NetworkServices.PortalBackend.DBAccess/Repositories/UserRepository.cs
@@ -102,7 +102,7 @@ public class UserRepository : IUserRepository
                     .Where(app => app.AppSubscriptionStatusId == AppSubscriptionStatusId.ACTIVE)
                     .Select(app => new CompanyUserAssignedRoleDetails(
                         app.AppId,
-                        app.App.IamClients
+                        app.App!.IamClients
                         .SelectMany(iamClient => iamClient.UserRoles
                             .Where(role => role.CompanyUsers.Any(user => user.Id == companyUser.Id))
                             .Select(role => role.UserRoleText))
@@ -182,7 +182,7 @@ public class UserRepository : IUserRepository
                     .Where(app => app.AppSubscriptionStatusId == AppSubscriptionStatusId.ACTIVE)
                     .Select(app => new CompanyUserAssignedRoleDetails(
                         app.AppId,
-                        app.App.IamClients
+                        app.App!.IamClients
                         .SelectMany(iamClient => iamClient.UserRoles
                             .Where(role => role.CompanyUsers.Any(user => user.Id == companyUser.Id))
                             .Select(role => role.UserRoleText))
@@ -217,7 +217,7 @@ public class UserRepository : IUserRepository
                     .Where(app => app.AppSubscriptionStatusId == AppSubscriptionStatusId.ACTIVE)
                     .Select(app => new CompanyUserAssignedRoleDetails(
                         app.AppId,
-                        app.App.IamClients
+                        app.App!.IamClients
                         .SelectMany(iamClient => iamClient.UserRoles
                             .Where(role => role.CompanyUsers.Any(user => user.Id == companyUser.Id))
                             .Select(role => role.UserRoleText))


### PR DESCRIPTION
in PR https://github.com/catenax-ng/product-portal-backend/pull/142 I did fix a code-smell of duplicated lines of code in the UserRepository-class by refactoring those duplicate lines into private methods.
It turned out efcore would not compile those queries the same way. For that reason until we find a working solution to refactor duplicate code in queries that commit needs to be reverted.