### PR TITLE
Fix module selection in veracode for marketplace app service

### DIFF
--- a/.github/workflows/veracode.yaml
+++ b/.github/workflows/veracode.yaml
@@ -218,7 +218,7 @@ jobs:
           filepath: "portal-backend-marketplace-app.zip"
           vid: "${{ secrets.ORG_VERACODE_API_ID }}"
           vkey: "${{ secrets.ORG_VERACODE_API_KEY }}"
-          include: 'CatenaX.NetworkServices.Apps.Service.dll, CatenaX.NetworkServices.Framework.DBAccess.dll, CatenaX.NetworkServices.Framework.Models.dll'
+          include: 'CatenaX.NetworkServices.Apps.Service.dll'
 
   analyze-portal-migrations:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Veracode now correctly identifies only the top level module but that requires us to remove the workaround which we had in place.