### PR TITLE
CPLP-1670 send type as string

### DIFF
--- a/src/administration/Administration.Service/BusinessLogic/SdFactoryService.cs
+++ b/src/administration/Administration.Service/BusinessLogic/SdFactoryService.cs
@@ -27,7 +27,6 @@ using Org.CatenaX.Ng.Portal.Backend.PortalBackend.PortalEntities.Enums;
 using System.Net.Http.Headers;
 using System.Security.Cryptography;
 using System.Text.Json;
-using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Org.CatenaX.Ng.Portal.Backend.Administration.Service.BusinessLogic;
 

--- a/src/administration/Administration.Service/BusinessLogic/SdFactoryService.cs
+++ b/src/administration/Administration.Service/BusinessLogic/SdFactoryService.cs
@@ -27,6 +27,7 @@ using Org.CatenaX.Ng.Portal.Backend.PortalBackend.PortalEntities.Enums;
 using System.Net.Http.Headers;
 using System.Security.Cryptography;
 using System.Text.Json;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Org.CatenaX.Ng.Portal.Backend.Administration.Service.BusinessLogic;
 

--- a/src/administration/Administration.Service/Models/SdFactoryRequestModel.cs
+++ b/src/administration/Administration.Service/Models/SdFactoryRequestModel.cs
@@ -18,6 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
+using System.Runtime.Serialization;
 using System.Text.Json.Serialization;
 
 namespace Org.CatenaX.Ng.Portal.Backend.Administration.Service.Models;
@@ -29,12 +30,13 @@ public record SdFactoryRequestModel(
     [property: JsonPropertyName("registrationNumber")] string RegistrationNumber,
     [property: JsonPropertyName("headquarterAddress.country")] string HeadquarterCountry,
     [property: JsonPropertyName("legalAddress.country")] string LegalCountry,
-    [property: JsonPropertyName("type")] SdFactoryRequestModelSdType Type,
+    [property: JsonPropertyName("type"), JsonConverter(typeof(JsonStringEnumConverter))] SdFactoryRequestModelSdType Type,
     [property: JsonPropertyName("bpn")] string Bpn,
     [property: JsonPropertyName("holder")] string Holder,
     [property: JsonPropertyName("issuer")] string Issuer);
 
 public enum SdFactoryRequestModelSdType
 {
+    [EnumMember(Value = "LegalPerson")]
     LegalPerson
 }


### PR DESCRIPTION
With this PR the type LegalPerson will no longer be send as an integer. Instead we send the type as an string.